### PR TITLE
fix: Dockerfile JRE 이미지 태그를 21-jre로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ./gradlew dependencies
 COPY src src
 RUN ./gradlew build -x test
 
-FROM --platform=linux/arm64 eclipse-temurin:21-jre-lunar
+FROM --platform=linux/arm64 eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080


### PR DESCRIPTION
## 📝 작업 내용
- Dockerfile JRE 이미지 태그를 21-jre로 수정

