### PR TITLE
fix: Dockerfile JRE 이미지 태그를 21-jre로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 eclipse-temurin:21-jdk-lunar as builder
+FROM --platform=linux/arm64 eclipse-temurin:21-jdk AS builder
 WORKDIR /app
 COPY gradlew ./
 COPY gradle gradle


### PR DESCRIPTION
## 📝 작업 내용
- Dockerfile JRE 이미지 태그를 21-jre로 수정
