### PR TITLE
fix: CD 워크플로우 라즈베리파이에 배포 시 docker hub에 로그인 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,14 +42,19 @@ jobs:
 
       # 4. 라즈베리파이에 배포
       - name: Deploy to Raspberry Pi
-        uses: appleboy/ssh-action@v0.1.9
+        uses: appleboy/ssh-action@v1.0.3 # 최신 버전 사용 권장
         with:
           host: ${{ secrets.RPI_HOST }}
           username: ${{ secrets.RPI_USER }}
           key: ${{ secrets.RPI_SSH_KEY }}
           port: ${{ secrets.RPI_SSH_PORT }}
           script: |
-            cd ~/taja || mkdir -p ~/taja && cd ~/taja
+            # Docker Hub에 로그인
+            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+              
+            TARGET_DIR=~/taja
+            mkdir -p "$TARGET_DIR"
+            cd "$TARGET_DIR" || exit 1
 
             # 1) .env 파일 생성
             cat > .env <<EOF


### PR DESCRIPTION
## 📝 작업 내용
- CD 워크플로우 라즈베리파이에 배포 시 docker hub에 로그인 추가
