### PR TITLE
Feature/#56 지도 화면 내 대여소 조회 API 분리

### DIFF
--- a/src/main/java/com/taja/application/station/StationFacade.java
+++ b/src/main/java/com/taja/application/station/StationFacade.java
@@ -13,11 +13,16 @@ import com.taja.domain.statistics.DayOfWeekStatistics;
 import com.taja.domain.statistics.HourlyStatistics;
 import com.taja.domain.statistics.TemperatureStatistics;
 import com.taja.interfaces.api.station.response.MapStationResponse;
+import com.taja.interfaces.api.station.response.NearbyStationsResponse;
+import com.taja.interfaces.api.station.response.StationClusterResponse;
 import com.taja.interfaces.api.station.response.detail.RecentPostResponse;
 import com.taja.interfaces.api.station.response.detail.StationDetailResponse;
 import com.taja.interfaces.api.station.response.detail.TodayAvailableBikeResponse;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +33,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class StationFacade {
 
     private static final int RECENT_POSTS_SIZE = 3;
+    private static final double CLUSTER_THRESHOLD = 0.03;
+    private static final int GRID_SIZE = 10;
 
     private final StationService stationService;
     private final StationCacheService stationCacheService;
@@ -45,15 +52,55 @@ public class StationFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<MapStationResponse> findStationsInBounds(double centerLat, double centerLon,
-                                                         double latDelta, double lonDelta) {
+    public NearbyStationsResponse findStationsInBounds(double centerLat, double centerLon,
+                                                       double latDelta, double lonDelta) {
         double height = (latDelta * 2) * 111.0;
         double width = (lonDelta * 2) * 88.8;
 
         List<StationInfo.StationGeoInfo> geoInfos = stationCacheService.findStationsInBounds(centerLat, centerLon, height, width);
-        List<StationInfo.StationFullInfo> stationInfos = stationCacheService.findStationInfos(geoInfos);
 
-        return StationInfo.StationFullInfo.toMapStationResponses(stationInfos);
+        if (latDelta >= CLUSTER_THRESHOLD || lonDelta >= CLUSTER_THRESHOLD) {
+            List<StationClusterResponse> clusters = clusterStations(geoInfos, centerLat, centerLon, latDelta, lonDelta);
+            return NearbyStationsResponse.ofClusters(clusters);
+        }
+
+        List<StationInfo.StationFullInfo> stationInfos = stationCacheService.findStationInfos(geoInfos);
+        List<MapStationResponse> responses = StationInfo.StationFullInfo.toMapStationResponses(stationInfos);
+        return NearbyStationsResponse.ofStations(responses);
+    }
+
+    private List<StationClusterResponse> clusterStations(List<StationInfo.StationGeoInfo> geoInfos,
+                                                          double centerLat, double centerLon,
+                                                          double latDelta, double lonDelta) {
+        double minLat = centerLat - latDelta;
+        double maxLat = centerLat + latDelta;
+        double minLon = centerLon - lonDelta;
+        double maxLon = centerLon + lonDelta;
+
+        double cellLatSize = (maxLat - minLat) / GRID_SIZE;
+        double cellLonSize = (maxLon - minLon) / GRID_SIZE;
+
+        Map<Long, Integer> cellCounts = new HashMap<>();
+
+        for (StationInfo.StationGeoInfo geo : geoInfos) {
+            int row = Math.min((int) ((geo.latitude() - minLat) / cellLatSize), GRID_SIZE - 1);
+            int col = Math.min((int) ((geo.longitude() - minLon) / cellLonSize), GRID_SIZE - 1);
+            row = Math.max(row, 0);
+            col = Math.max(col, 0);
+            long cellKey = (long) row * GRID_SIZE + col;
+            cellCounts.merge(cellKey, 1, Integer::sum);
+        }
+
+        List<StationClusterResponse> clusters = new ArrayList<>();
+        for (Map.Entry<Long, Integer> entry : cellCounts.entrySet()) {
+            int row = (int) (entry.getKey() / GRID_SIZE);
+            int col = (int) (entry.getKey() % GRID_SIZE);
+            double clusterLat = minLat + (row + 0.5) * cellLatSize;
+            double clusterLon = minLon + (col + 0.5) * cellLonSize;
+            clusters.add(new StationClusterResponse(clusterLat, clusterLon, entry.getValue()));
+        }
+
+        return clusters;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/taja/interfaces/api/station/StationController.java
+++ b/src/main/java/com/taja/interfaces/api/station/StationController.java
@@ -15,6 +15,7 @@ import com.taja.interfaces.api.station.request.NearbyStationRequest;
 import com.taja.interfaces.api.station.request.SearchStationRequest;
 import com.taja.interfaces.api.station.response.IsFavoriteStationResponse;
 import com.taja.interfaces.api.station.response.MapStationResponse;
+import com.taja.interfaces.api.station.response.NearbyStationsResponse;
 import com.taja.interfaces.api.station.response.StationStatusResponse;
 import com.taja.interfaces.api.station.response.PostItemResponse;
 import com.taja.interfaces.api.station.response.PostListResponse;
@@ -64,16 +65,16 @@ public class StationController {
 
     @Operation(summary = "지도 화면 영역 내 대여소 조회", description = "지도 중심 좌표와 화면에 보이는 영역의 위도, 경도 차이를 이용해 근처 대여소를 조회합니다.")
     @GetMapping("/map/nearby")
-    public CommonApiResponse<List<MapStationResponse>> findStationsInBounds(
+    public CommonApiResponse<NearbyStationsResponse> findStationsInBounds(
             @Valid @ModelAttribute NearbyStationRequest nearbyStationRequest) {
-        List<MapStationResponse> stationsInBounds = stationFacade.findStationsInBounds(
+        NearbyStationsResponse response = stationFacade.findStationsInBounds(
                 nearbyStationRequest.latitude(),
                 nearbyStationRequest.longitude(),
                 nearbyStationRequest.latDelta(),
                 nearbyStationRequest.lngDelta()
         );
 
-        return CommonApiResponse.success(stationsInBounds, "근처 대여소 조회에 성공했습니다.");
+        return CommonApiResponse.success(response, "근처 대여소 조회에 성공했습니다.");
     }
 
     @Operation(summary = "대여소 검색", description = "키워드와 지도 중심 좌표를 이용해 대여소를 검색합니다.")

--- a/src/main/java/com/taja/interfaces/api/station/response/NearbyStationsResponse.java
+++ b/src/main/java/com/taja/interfaces/api/station/response/NearbyStationsResponse.java
@@ -1,0 +1,18 @@
+package com.taja.interfaces.api.station.response;
+
+import java.util.List;
+
+public record NearbyStationsResponse(
+        String viewType,
+        List<MapStationResponse> stations,
+        List<StationClusterResponse> clusters
+) {
+
+    public static NearbyStationsResponse ofStations(List<MapStationResponse> stations) {
+        return new NearbyStationsResponse("stations", stations, null);
+    }
+
+    public static NearbyStationsResponse ofClusters(List<StationClusterResponse> clusters) {
+        return new NearbyStationsResponse("clusters", null, clusters);
+    }
+}

--- a/src/main/java/com/taja/interfaces/api/station/response/StationClusterResponse.java
+++ b/src/main/java/com/taja/interfaces/api/station/response/StationClusterResponse.java
@@ -1,0 +1,8 @@
+package com.taja.interfaces.api.station.response;
+
+public record StationClusterResponse(
+        double latitude,
+        double longitude,
+        int stationCount
+) {
+}

--- a/src/test/java/com/taja/application/station/StationFacadeIntegrationTest.java
+++ b/src/test/java/com/taja/application/station/StationFacadeIntegrationTest.java
@@ -6,13 +6,18 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.taja.application.board.BoardInfo;
 import com.taja.application.board.PostService;
 import com.taja.application.cache.StationCacheService;
+import com.taja.application.cache.StationInfo;
 import com.taja.application.status.StationStatusFacade;
 import com.taja.domain.station.OperationMode;
 import com.taja.domain.station.Station;
+import com.taja.interfaces.api.station.response.NearbyStationsResponse;
+import com.taja.interfaces.api.station.response.StationClusterResponse;
 import com.taja.interfaces.api.station.response.detail.StationDetailResponse;
 import com.taja.interfaces.api.station.response.detail.TodayAvailableBikeResponse;
 import java.time.LocalDateTime;
@@ -87,5 +92,140 @@ class StationFacadeIntegrationTest {
         assertThat(response.hourlyAvailable()).isNotNull();
         assertThat(response.dailyAvailable()).isNotNull();
         assertThat(response.temperatureAvailable()).isNotNull();
+    }
+
+    @DisplayName("좁은 영역(delta < 0.03) 조회 시 viewType이 stations이고 개별 대여소 정보를 반환한다.")
+    @Test
+    void findStationsInBounds_narrowArea_returnsStations() {
+        // given
+        double centerLat = 37.5;
+        double centerLon = 127.0;
+        double latDelta = 0.01;
+        double lonDelta = 0.01;
+
+        List<StationInfo.StationGeoInfo> geoInfos = List.of(
+                new StationInfo.StationGeoInfo(101, 37.501, 127.001),
+                new StationInfo.StationGeoInfo(102, 37.502, 127.002)
+        );
+
+        LocalDateTime now = LocalDateTime.now();
+        List<StationInfo.StationFullInfo> fullInfos = List.of(
+                new StationInfo.StationFullInfo(1L, 101, 37.501, 127.001, 5, now),
+                new StationInfo.StationFullInfo(2L, 102, 37.502, 127.002, 3, now)
+        );
+
+        given(stationCacheService.findStationsInBounds(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .willReturn(geoInfos);
+        given(stationCacheService.findStationInfos(geoInfos))
+                .willReturn(fullInfos);
+
+        // when
+        NearbyStationsResponse response = stationFacade.findStationsInBounds(centerLat, centerLon, latDelta, lonDelta);
+
+        // then
+        assertThat(response.viewType()).isEqualTo("stations");
+        assertThat(response.stations()).hasSize(2);
+        assertThat(response.clusters()).isNull();
+        verify(stationCacheService).findStationInfos(geoInfos);
+    }
+
+    @DisplayName("넓은 영역(delta >= 0.03) 조회 시 viewType이 clusters이고 Redis Hash 조회를 하지 않는다.")
+    @Test
+    void findStationsInBounds_wideArea_returnsClustersWithoutHashLookup() {
+        // given
+        double centerLat = 37.5;
+        double centerLon = 127.0;
+        double latDelta = 0.05;
+        double lonDelta = 0.05;
+
+        List<StationInfo.StationGeoInfo> geoInfos = List.of(
+                new StationInfo.StationGeoInfo(101, 37.51, 127.01),
+                new StationInfo.StationGeoInfo(102, 37.52, 127.02),
+                new StationInfo.StationGeoInfo(103, 37.51, 127.01)
+        );
+
+        given(stationCacheService.findStationsInBounds(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .willReturn(geoInfos);
+
+        // when
+        NearbyStationsResponse response = stationFacade.findStationsInBounds(centerLat, centerLon, latDelta, lonDelta);
+
+        // then
+        assertThat(response.viewType()).isEqualTo("clusters");
+        assertThat(response.clusters()).isNotEmpty();
+        assertThat(response.stations()).isNull();
+        verify(stationCacheService, never()).findStationInfos(any());
+    }
+
+    @DisplayName("같은 셀에 속하는 대여소들은 하나의 클러스터로 묶인다.")
+    @Test
+    void findStationsInBounds_stationsInSameCell_groupedIntoOneCluster() {
+        // given
+        double centerLat = 37.5;
+        double centerLon = 127.0;
+        double latDelta = 0.05;
+        double lonDelta = 0.05;
+
+        // 같은 셀에 속하도록 아주 가까운 좌표 3개
+        List<StationInfo.StationGeoInfo> geoInfos = List.of(
+                new StationInfo.StationGeoInfo(101, 37.501, 127.001),
+                new StationInfo.StationGeoInfo(102, 37.502, 127.002),
+                new StationInfo.StationGeoInfo(103, 37.501, 127.001)
+        );
+
+        given(stationCacheService.findStationsInBounds(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .willReturn(geoInfos);
+
+        // when
+        NearbyStationsResponse response = stationFacade.findStationsInBounds(centerLat, centerLon, latDelta, lonDelta);
+
+        // then
+        assertThat(response.clusters()).hasSize(1);
+        StationClusterResponse cluster = response.clusters().getFirst();
+        assertThat(cluster.stationCount()).isEqualTo(3);
+    }
+
+    @DisplayName("서로 다른 셀에 속하는 대여소들은 별도의 클러스터로 분리된다.")
+    @Test
+    void findStationsInBounds_stationsInDifferentCells_separateClusters() {
+        // given
+        double centerLat = 37.5;
+        double centerLon = 127.0;
+        double latDelta = 0.05;
+        double lonDelta = 0.05;
+
+        // 서로 다른 셀에 속하도록 멀리 떨어진 좌표
+        List<StationInfo.StationGeoInfo> geoInfos = List.of(
+                new StationInfo.StationGeoInfo(101, 37.46, 126.96),
+                new StationInfo.StationGeoInfo(102, 37.54, 127.04)
+        );
+
+        given(stationCacheService.findStationsInBounds(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .willReturn(geoInfos);
+
+        // when
+        NearbyStationsResponse response = stationFacade.findStationsInBounds(centerLat, centerLon, latDelta, lonDelta);
+
+        // then
+        assertThat(response.clusters()).hasSize(2);
+        assertThat(response.clusters())
+                .extracting(StationClusterResponse::stationCount)
+                .containsExactlyInAnyOrder(1, 1);
+    }
+
+    @DisplayName("대여소가 없는 넓은 영역 조회 시 빈 클러스터 목록을 반환한다.")
+    @Test
+    void findStationsInBounds_wideAreaNoStations_returnsEmptyClusters() {
+        // given
+        given(stationCacheService.findStationsInBounds(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .willReturn(Collections.emptyList());
+
+        // when
+        NearbyStationsResponse response = stationFacade.findStationsInBounds(37.5, 127.0, 0.05, 0.05);
+
+        // then
+        assertThat(response.viewType()).isEqualTo("clusters");
+        assertThat(response.clusters()).isEmpty();
+        assertThat(response.stations()).isNull();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 지도 넓은 영역 조회 시 클러스터링 응답으로 분리                                                                                                                                                                                                                                                                                                                                     
  - 요청 영역의 delta 값(0.03)을 기준으로 응답 전략 분기                                                                                                                                                
    - **좁은 영역 (delta < 0.03)**: 기존과 동일하게 개별 대여소 + 자전거 수 반환                                                                                                                        
    - **넓은 영역 (delta >= 0.03)**: Redis Hash 조회를 생략하고 10x10 그리드 클러스터링으로 구역별 대여소 수 반환                                                                      

## 🔗 관련 이슈
#56 

