### PR TITLE
fix: 서버 시간 오류 해결 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ FROM --platform=linux/arm64 eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]


### PR DESCRIPTION
## 📝 작업 내용
- Dockerfile에 -Duser.timezone=Asia/Seoul JVM 옵션을 추가

## 🔗 관련 이슈
#70 

